### PR TITLE
Fix loadEditorScriptAssets for duplicate items

### DIFF
--- a/src/sdk/core/assets.ts
+++ b/src/sdk/core/assets.ts
@@ -49,6 +49,11 @@ export async function loadEditorScriptAssets(
   for (const scriptType of scriptTypes) {
     const item = editor.call("assets:scripts:assetByScript", scriptType);
 
+    if (item === null) {
+      console.warn(`No item found for scriptType: ${scriptType}`);
+      continue;
+    }
+
     const asset = this.app.assets.get(item.get("id"));
     asset.unload();
 


### PR DESCRIPTION
We had a problem where we had (due to merging) multiple files, creating the same script.

This caused an exception when loading the assets.

This fix will skip items that are no longer found, because they have been already processed.